### PR TITLE
UI-parannus Finnkino

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "postman.settings.dotenv-detection-notification-visibility": false
+}

--- a/frontend/src/components/MovieCard.js
+++ b/frontend/src/components/MovieCard.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import '../styles/MovieCard.css';
+
+
+function MovieCard({ title, image, onClick }) {
+    return (
+        <div className="movie-card" onClick={onClick} style={{ cursor: 'pointer' }}>
+            {image && <img src={image} alt={title} className="movie-poster" />}
+            <h3>{title}</h3>
+        </div>
+    );
+}
+
+export default MovieCard;

--- a/frontend/src/components/MovieModal.js
+++ b/frontend/src/components/MovieModal.js
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from 'react';
+import '../styles/MovieModal.css';
+
+function MovieModal({ movie, areaId, onClose }) {
+    const [details, setDetails] = useState(null);
+    const [groupedShowtimes, setGroupedShowtimes] = useState({});
+    const [expanded, setExpanded] = useState(false); // uusi tila
+
+    useEffect(() => {
+        if (!movie) return;
+
+        const fetchDetails = async () => {
+            try {
+                const res = await fetch(`https://www.finnkino.fi/xml/Events/?includeVideos=true&includeLinks=true`);
+                const xmlText = await res.text();
+                const xmlDoc = new DOMParser().parseFromString(xmlText, 'text/xml');
+                const events = xmlDoc.getElementsByTagName('Event');
+
+                for (let i = 0; i < events.length; i++) {
+                    const event = events[i];
+                    const title = event.getElementsByTagName('Title')[0]?.textContent?.trim();
+                    if (title === movie.title) {
+                        const synopsis = event.getElementsByTagName('Synopsis')[0]?.textContent;
+                        const eventID = event.getElementsByTagName('ID')[0]?.textContent;
+                        setDetails({ synopsis, eventID });
+                        break;
+                    }
+                }
+            } catch (err) {
+                console.error('Elokuvan lisätietojen haku epäonnistui:', err);
+            }
+        };
+
+        fetchDetails();
+    }, [movie]);
+
+    useEffect(() => {
+    setExpanded(false); // resetoi "Näytä lisää" aina kun uusi elokuva avataan
+}, [movie]);
+
+
+    useEffect(() => {
+        if (!details?.eventID || !areaId) return;
+
+        const fetchShowtimes = async () => {
+            try {
+                const res = await fetch(`https://www.finnkino.fi/xml/Schedule/?area=${areaId}&eventID=${details.eventID}&nrOfDays=7`);
+                const xmlText = await res.text();
+                const xmlDoc = new DOMParser().parseFromString(xmlText, 'text/xml');
+                const showsXml = xmlDoc.getElementsByTagName('Show');
+
+                const grouped = {};
+                for (let i = 0; i < showsXml.length; i++) {
+                    const show = showsXml[i];
+                    const startTime = show.getElementsByTagName('dttmShowStart')[0]?.textContent;
+                    if (startTime) {
+                        const date = new Date(startTime).toLocaleDateString('fi-FI', {
+                            weekday: 'long',
+                            day: '2-digit',
+                            month: '2-digit'
+                        });
+                        if (!grouped[date]) {
+                            grouped[date] = [];
+                        }
+                        grouped[date].push(
+                            new Date(startTime).toLocaleTimeString('fi-FI', {
+                                hour: '2-digit',
+                                minute: '2-digit'
+                            })
+                        );
+                    }
+                }
+
+                setGroupedShowtimes(grouped);
+            } catch (err) {
+                console.error('Näytösaikojen haku epäonnistui:', err);
+            }
+        };
+
+        fetchShowtimes();
+    }, [details, areaId]);
+
+    if (!movie) return null;
+
+    const shortText = details?.synopsis?.slice(0, 300); // lyhyt versio
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+                <button className="close-button" onClick={onClose}>×</button>
+                <div className="modal-layout">
+                    <img src={movie.image} alt={movie.title} className="modal-poster" />
+                    <div className="modal-info">
+                        <h2>{movie.title}</h2>
+                        {details?.synopsis && (
+                            <>
+                                <p>
+                                    {expanded ? details.synopsis : `${shortText}...`}
+                                </p>
+                                <button className="toggle-button" onClick={() => setExpanded(!expanded)}>
+                                    {expanded ? 'Näytä vähemmän' : 'Näytä lisää'}
+                                </button>
+                            </>
+                        )}
+                        <h4>Näytösajat (7 päivää):</h4>
+                        <div className="scroll-box">
+                            {Object.entries(groupedShowtimes).map(([date, times], index) => (
+                                <div key={index} className="showtime-day">
+                                    <strong>{date}</strong><br />
+                                    {times.join(', ')}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default MovieModal;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,6 @@
 body {
   margin: 0;
+  background-color: #121212; /* pehmeä musta tausta */
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;

--- a/frontend/src/styles/MovieCard.css
+++ b/frontend/src/styles/MovieCard.css
@@ -1,0 +1,38 @@
+.movie-card {
+    background: #363636;
+    padding: 1rem;
+    border-radius: 8px;
+    text-align: center;
+    box-shadow: 0 2px 6px rgba(255, 215, 0, 0.2); /* keltainen varjo */
+    color: #fff;
+    border: none;
+    transition: transform 0.2s ease;
+}
+
+.movie-card:hover {
+    box-shadow: 0 0 30px 6px rgba(255, 215, 0, 0.7), 0 0 0 2px #FFD700 inset;
+    transform: translateY(-4px); /* pieni nosto */
+    cursor: pointer;
+    border: none;
+}
+
+.movie-poster {
+    width: 100%;
+    height: auto;
+    border-radius: 4px;
+    margin-bottom: 0.5rem;
+    border: none;
+}
+
+.showtime-list {
+    list-style: none;
+    padding: 0;
+    margin-top: 0.5rem;
+    color: #fff;
+}
+
+.showtime-list li {
+    margin-bottom: 0.3rem;
+    font-size: 0.95rem;
+}
+

--- a/frontend/src/styles/MovieModal.css
+++ b/frontend/src/styles/MovieModal.css
@@ -1,0 +1,132 @@
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.85);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background-color: #1a1a1a;
+    color: #fff; /* leipäteksti valkoiseksi */
+    padding: 2rem;
+    border-radius: 8px;
+    max-width: 900px;
+    width: 95%;
+    position: relative;
+    box-shadow: 0 0 20px rgba(255, 215, 0, 0.2);
+    max-height: 90vh;
+    overflow-y: auto;
+}
+
+.modal-layout {
+    display: flex;
+    gap: 2rem;
+    flex-wrap: wrap;
+    align-items: flex-start; /* estää kuvan venymisen */
+}
+
+.modal-poster {
+    width: 300px;
+    flex-shrink: 0; /* estää kutistumisen */
+    flex-grow: 0;   /* estää venymisen */
+    border-radius: 4px;
+    border: 2px solid #333;
+    object-fit: cover;
+}
+
+
+.modal-info {
+    flex: 1;
+    min-width: 250px;
+}
+
+.modal-info h2 {
+  color: #FFD700; /* elokuvan nimi keltaisella */
+  margin-top: 0;
+}
+
+.modal-info p {
+  color: #fff; /* kuvaus valkoisella */
+  line-height: 1.6;
+  margin-bottom: 1rem;
+}
+
+
+.close-button {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: transparent;
+    border: none;
+    font-size: 2rem;
+    color: #FFD700;
+    cursor: pointer;
+}
+
+.scroll-box {
+    max-height: 200px;
+    overflow-y: auto;
+    padding: 1rem;
+    margin-top: 0.5rem;
+    background-color: #121212;
+    border: 1px solid #333; /* hillitty reunus */
+    border-radius: 6px;
+    scrollbar-width: thin;
+    scrollbar-color: #555 #121212;
+}
+
+.scroll-box::-webkit-scrollbar {
+    width: 8px;
+}
+
+.scroll-box::-webkit-scrollbar-track {
+    background: #121212;
+}
+
+.scroll-box::-webkit-scrollbar-thumb {
+    background-color: #555;
+    border-radius: 4px;
+}
+
+.showtime-day {
+    margin-bottom: 1rem;
+    line-height: 1.4;
+    color: #fff;
+}
+
+.toggle-button {
+    background: none;
+    border: none;
+    color: #FFD700;
+    font-weight: bold;
+    cursor: pointer;
+    margin-bottom: 1rem;
+    padding: 0;
+    font-size: 0.95rem;
+    text-decoration: underline;
+}
+
+/* Scrollbar modaalin pääsisällölle */
+.modal-content::-webkit-scrollbar {
+    width: 8px;
+}
+
+.modal-content::-webkit-scrollbar-track {
+    background: #1a1a1a;
+}
+
+.modal-content::-webkit-scrollbar-thumb {
+    background-color: #444;
+    border-radius: 4px;
+}
+
+.modal-content {
+    scrollbar-width: thin;
+    scrollbar-color: #444 #1a1a1a;
+}

--- a/frontend/src/styles/Showtimes.css
+++ b/frontend/src/styles/Showtimes.css
@@ -1,0 +1,39 @@
+.showtimes-container {
+    padding: 2rem;
+    max-width: 1200px;
+    margin: auto;
+    background-color: transparent; /* ei tarvitse erillistä taustaa */
+    color: #FFD700;
+    line-height: 1.6;
+}
+
+
+label {
+    font-weight: bold;
+    margin-right: 0.5rem;
+    color: #FFD700;
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+select {
+    margin-bottom: 1.5rem;
+    padding: 0.5rem;
+    background-color: #222;
+    color: #FFD700;
+    border: 1px solid #FFD700;
+    border-radius: 4px;
+}
+
+.show-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 2rem; /* enemmän väliä korttien väliin */
+    margin-top: 2rem;
+}
+
+.error-message {
+    color: red;
+    font-weight: bold;
+    margin-bottom: 1rem;
+}


### PR DESCRIPTION
Muokattu Finnkinon näytöshakua.

-Lisätty elokuvien posterit näkyviin
-Elokuvateatterin tai kaupungin voi nyt valita dropdown valikosta
-Espoon näytösajat poistettu, Finnkino ei niitä enää tuon API:n kautta tarjoa
-Ryhmitetty näytökset elokuvan mukaan --> näytetään vain yksi posteri per elokuva
-Posteria klikkaamalla näkyy kyseisen leffan kuvaus ja näytösajat
-Tyylejä alettu muokkaamaan omissa tiedostoissaan (Finnkinon tyyliin keltainen/musta?)